### PR TITLE
Хотфиксы багов API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wiki Tarkov Project
 [![GitHub Actions](https://github.com/PC-Principal/wiki-tarkov/actions/workflows/DockerApp-Actions.yml/badge.svg)](https://github.com/PC-Principal/wiki-tarkov/actions/workflows/DockerApp-Actions.yml)
 [![Deploy on Prod](https://github.com/PC-Principal/wiki-tarkov/actions/workflows/DeployProd.yml/badge.svg?branch=master)](https://github.com/PC-Principal/wiki-tarkov/actions/workflows/DeployProd.yml)
 ![Site status](https://img.shields.io/badge/site%20status-works-success)
-![Stable Version](https://img.shields.io/badge/version-v2.9.24-brightgreen)
+![Stable Version](https://img.shields.io/badge/version-v2.9.25-brightgreen)
 ![Stable branch](https://img.shields.io/badge/Stable%20branch-master-success)
 ![Tests Count](https://img.shields.io/badge/tests%20count-1017-informational)
 ![Tests Code Coverage](https://img.shields.io/badge/coverage-68%25-yellowgreen)

--- a/models/Bosses.php
+++ b/models/Bosses.php
@@ -91,7 +91,7 @@ class Bosses extends \yii\db\ActiveRecord
      */
     public static function getBossData(string $map_url): string
     {
-        return Bosses::find()->select(static::ATTR_BOSSES)->where([Bosses::ATTR_URL => $map_url])->scalar();
+        return Bosses::find()->select(Bosses::ATTR_BOSSES)->where([Bosses::ATTR_URL => $map_url])->scalar();
     }
 
     /**

--- a/views/api/item.php
+++ b/views/api/item.php
@@ -123,7 +123,7 @@ $this->registerJsFile('js/news.js', ['depends' => [JqueryAsset::class]]);
                 <!-- barters block -->
                 <?php foreach($item->json['bartersFor'] as $barter) : ?>
 
-                    <div class="barters-block row">
+                    <div class="barters-block-actual row">
 
                         <div class="col-sm-2">
                             <img class="detail-item-trader" src="<?= ImageService::traderImages($barter['trader']['name']) ?>" title="<?= $barter['trader']['name'] ?>" alt="<?= $barter['trader']['name'] ?>">

--- a/views/bosses/view.php
+++ b/views/bosses/view.php
@@ -73,7 +73,7 @@ $this->registerMetaTag([
 
                     <!-- Attributes -->
                     <div class="col-sm-10">
-                        <p class="boss-page-text boss-spawn-chance">Шанс спавна: <b><?= $boss['spawnChance'] ?>%</b></p>
+                        <p class="boss-page-text boss-spawn-chance">Шанс спавна: <b><?= $boss['spawnChance'] * 100 ?>%</b></p>
                         <p class="boss-page-text boss-spawn-locations">Зона спавна: <b><?= implode(', ', TranslateService::setZoneNames(ArrayHelper::getColumn($boss['spawnLocations'], 'name'))) ?></b>
                         <p class="boss-page-text boss-group">Действует в одиночку: <b><?= empty($boss['escorts']) ? 'Да' : 'Нет' ?></b></p>
                         <p class="boss-page-text boss-spawn-time">Спавнится при определенных условиях: <b><?= ($boss['spawnTimeRandom'] == 'true') ? 'Да' : 'Нет' ?></b>

--- a/web/css/custom.css
+++ b/web/css/custom.css
@@ -2235,7 +2235,7 @@ table.patrons-tbl >thead > tr > th {
 }
 
 /** Блок купли и продажи **/
-.selling-block, .buying-block, .barters-block, .received-block {
+.selling-block, .buying-block, .barters-block-actual, .received-block {
     padding: 10px;
     background: #80808033;
     margin: 20px auto;


### PR DESCRIPTION
Поправили шансы спавна боссов на локациях, т.к. там нужно было умножать на 100 имеющееся число в API. Также поправили фоны на страницах торговцев (На страницах лута API был продублирован существующий CSS класс).