### PR TITLE
Фикс багов с отображением локации Улицы Таркова на мобильных устройствах

### DIFF
--- a/views/maps/streets-of-tarkov.php
+++ b/views/maps/streets-of-tarkov.php
@@ -28,7 +28,7 @@ $this->registerMetaTag([
 
 <!-- Инициализация карты -->
 <div class="w-100">
-    <div id="map" class="map relative">
+    <div id="map" class="map map-alternative relative">
 
         <!-- Координаты мышки -->
         <div id="mapCoords" data-original-title="" title=""></div>

--- a/web/css/media-queryes.css
+++ b/web/css/media-queryes.css
@@ -319,7 +319,34 @@
     /** Отступы и размер шрифты для боковой менюшки на мобильных устройствах уменьшены */
     .leaflet-control-layers.leaflet-control > .all-map-blocks > .form-control {
         font-size: 10px;
-        margin: 5px 0;
+        margin: 2px 0;
+        height: 28px;
+    }
+
+    /** Уменьшение шрифта карты, на мобильных устройствах */
+    .mapcenter a.btn.btn-default.main-link {
+        font-size: 13px;
+        padding: 5px;
+        left: 4px;
+    }
+
+    /** Высота интерактивных карт снижена на мобильных устройствах */
+    .map-alternative {
+        height: 546px;
+    }
+
+    /** Отступы интерактивных элементов Leaflet JS уменьшены на интерактивных картах локаций */
+    .leaflet-touch .leaflet-control-layers, .leaflet-touch .leaflet-bar {
+        padding: 10px;
+    }
+
+    /** Фикс Leaflet JS сепаратора */
+    .leaflet-control-layers-separator {
+        margin: 5px -5px 5px -5px;
+    }
+
+    #mapCoords {
+        display: none;
     }
 }
 


### PR DESCRIPTION
Фикс багов с отображением локации Улицы Таркова на мобильных устройствах.

- Положение координат отключено
- Кнопка "Вернуться к центру карты" теперь в левой части экрана
- Отступы навигационных элементов Leaflet JS уменьшены