### PR TITLE
Отключаем возврат маркеров по прямому URL

### DIFF
--- a/common/services/MarkersService.php
+++ b/common/services/MarkersService.php
@@ -13,9 +13,7 @@ use app\models\Zavod;
 use app\models\Forest;
 use app\models\Tamojnya;
 use app\models\Bereg;
-use yii\web\HttpException;
 use yii\helpers\Json;
-use Yii;
 
 /**
  * Класс для работы с маркерами для интерактивных карт
@@ -28,37 +26,34 @@ final class MarkersService
     /**
      * Метод вытаскивает маркеры, по переданному значению
      *
-     * @param string $map_title - название карты
+     * @param string $map_title - название карты (Совпадает с названием таблицы)
      * @return string
-     * @throws HttpException
      */
     public static function takeMarkers(string $map_title): string
     {
-        if (Yii::$app->request->isAjax) {
+        /** Переменная с маркерами для return'a */
+        $markers = '';
 
-            $markers = '';
-
-            switch ($map_title) {
-                case 'zavod':
-                    $markers = Zavod::takeMarkers();
-                    break;
-                case 'tamojnya':
-                    $markers = Tamojnya::takeMarkers();
-                    break;
-                case 'forest':
-                    $markers = Forest::takeMarkers();
-                    break;
-                case 'bereg':
-                    $markers = Bereg::takeMarkers();
-                    break;
-                case 'razvyazka':
-                    $markers = Razvyazka::takeMarkers();
-                    break;
-            }
-
-            return Json::encode($markers);
+        /** В свиче в зависимости от названия карты вернем нужный набор маркеров */
+        switch ($map_title) {
+            case 'zavod':
+                $markers = Zavod::takeMarkers();
+                break;
+            case 'tamojnya':
+                $markers = Tamojnya::takeMarkers();
+                break;
+            case 'forest':
+                $markers = Forest::takeMarkers();
+                break;
+            case 'bereg':
+                $markers = Bereg::takeMarkers();
+                break;
+            case 'razvyazka':
+                $markers = Razvyazka::takeMarkers();
+                break;
         }
 
-        throw new HttpException(404 ,'Такая страница не существует');
+        /** Возвращает маркеры, приведенные к JSON виду */
+        return Json::encode($markers);
     }
 }

--- a/controllers/MapsController.php
+++ b/controllers/MapsController.php
@@ -17,6 +17,7 @@ use app\models\Bereg;
 use app\models\Razvyazka;
 use app\models\Laboratory;
 use Yii;
+use yii\web\HttpException;
 
 /**
  * Это контроллер интерактивных карт
@@ -46,6 +47,12 @@ class MapsController extends AdvancedController
 
     /**
      * Массив поведения данного контроллера
+     * В variations указаны вариации страниц, у которых будет раздельный кэш - например:
+     * - URL реквеста
+     * - AJAX или нет
+     * - Код ответа страницы
+     * - Наличие параметра GET page
+     * - Наличие куки Overlay для рекламы
      *
      * @return array|array[]
      */
@@ -58,6 +65,7 @@ class MapsController extends AdvancedController
                 'variations' => [
                     $_SERVER['SERVER_NAME'],
                     Yii::$app->request->url,
+                    Yii::$app->request->isAjax,
                     Yii::$app->response->statusCode,
                     Yii::$app->request->get('page'),
                     Yii::$app->request->cookies->get('overlay')
@@ -79,61 +87,115 @@ class MapsController extends AdvancedController
     /**
      * JSON данные с координатами маркеров Завода
      *
+     * @throws HttpException
      * @return string
      */
     public function actionZavodmarkers(): string
     {
-        return MarkersService::takeMarkers(Zavod::tableName());
+        /** Проверяем что запрос идет по Ajax */
+        if (Yii::$app->request->isAjax) {
+
+            /** Возвращаем маркеры по названия таблицы в виде JSON */
+            return MarkersService::takeMarkers(Zavod::tableName());
+        }
+
+        /** Если запрос к странице был не по Ajax - всегда выкидываем 404 ошибку */
+        throw new HttpException(404, 'Такая страница не найдена');
     }
 
     /**
      * JSON данные с координатами маркеров Леса
      *
+     * @throws HttpException
      * @return string
      */
     public function actionForestmarkers(): string
     {
-        return MarkersService::takeMarkers(Forest::tableName());
+        /** Проверяем что запрос идет по Ajax */
+        if (Yii::$app->request->isAjax) {
+
+            /** Возвращаем маркеры по названия таблицы в виде JSON */
+            return MarkersService::takeMarkers(Forest::tableName());
+        }
+
+        /** Если запрос к странице был не по Ajax - всегда выкидываем 404 ошибку */
+        throw new HttpException(404, 'Такая страница не найдена');
     }
 
     /**
      * JSON данные с координатами маркеров Таможни
      *
+     * @throws HttpException
      * @return string
      */
     public function actionTamojnyamarkers(): string
     {
-        return MarkersService::takeMarkers(Tamojnya::tableName());
+        /** Проверяем что запрос идет по Ajax */
+        if (Yii::$app->request->isAjax) {
+
+            /** Возвращаем маркеры по названия таблицы в виде JSON */
+            return MarkersService::takeMarkers(Tamojnya::tableName());
+        }
+
+        /** Если запрос к странице был не по Ajax - всегда выкидываем 404 ошибку */
+        throw new HttpException(404, 'Такая страница не найдена');
     }
 
     /**
      * JSON данные с координатами маркеров Берега
      *
+     * @throws HttpException
      * @return string
      */
     public function actionBeregmarkers(): string
     {
-        return MarkersService::takeMarkers(Bereg::tableName());
+        /** Проверяем что запрос идет по Ajax */
+        if (Yii::$app->request->isAjax) {
+
+            /** Возвращаем маркеры по названия таблицы в виде JSON */
+            return MarkersService::takeMarkers(Bereg::tableName());
+        }
+
+        /** Если запрос к странице был не по Ajax - всегда выкидываем 404 ошибку */
+        throw new HttpException(404, 'Такая страница не найдена');
     }
 
     /**
      * JSON данные с координатами маркеров Развязки
      *
+     * @throws HttpException
      * @return string
      */
     public function actionRazvyazkamarkers(): string
     {
-        return MarkersService::takeMarkers(Razvyazka::tableName());
+        /** Проверяем что запрос идет по Ajax */
+        if (Yii::$app->request->isAjax) {
+
+            /** Возвращаем маркеры по названия таблицы в виде JSON */
+            return MarkersService::takeMarkers(Razvyazka::tableName());
+        }
+
+        /** Если запрос к странице был не по Ajax - всегда выкидываем 404 ошибку */
+        throw new HttpException(404, 'Такая страница не найдена');
     }
 
     /**
      * JSON данные с координатами маркеров Лаборатории
      *
+     * @throws HttpException
      * @return string
      */
     public function actionLaboratorymarkers(): string
     {
-        return MarkersService::takeMarkers(Laboratory::tableName());
+        /** Проверяем что запрос идет по Ajax */
+        if (Yii::$app->request->isAjax) {
+
+            /** Возвращаем маркеры по названия таблицы в виде JSON */
+            return MarkersService::takeMarkers(Laboratory::tableName());
+        }
+
+        /** Если запрос к странице был не по Ajax - всегда выкидываем 404 ошибку */
+        throw new HttpException(404, 'Такая страница не найдена');
     }
 
     /**


### PR DESCRIPTION
Теперь если запрос не по AJAX, конечный URL не вернет данные маркеров для интерактивных карт.