### PR TITLE
Убраны ненужные индексы для рекламных блоков на страницах ключей

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wiki Tarkov Project 💻
 [![GitHub Actions](https://github.com/PC-Principal/wiki-tarkov/actions/workflows/DockerApp-Actions.yml/badge.svg)](https://github.com/PC-Principal/wiki-tarkov/actions/workflows/DockerApp-Actions.yml)
 [![Deploy on Prod](https://github.com/PC-Principal/wiki-tarkov/actions/workflows/DeployProd.yml/badge.svg?branch=master)](https://github.com/PC-Principal/wiki-tarkov/actions/workflows/DeployProd.yml)
 ![Site status](https://img.shields.io/badge/site%20status-works-success)
-![Stable Version](https://img.shields.io/badge/version-v4.8.3-brightgreen)
+![Stable Version](https://img.shields.io/badge/version-v4.8.41-brightgreen)
 ![Stable branch](https://img.shields.io/badge/Stable%20branch-master-success)
 ![Tests Count](https://img.shields.io/badge/tests%20count-848-informational)
 ![Tests Code Coverage](https://img.shields.io/badge/coverage-95%25-yellowgreen)

--- a/views/site/keys/index.php
+++ b/views/site/keys/index.php
@@ -80,14 +80,6 @@ $this->registerMetaTag([
                 <h2 class="keys-titles">Ключи на локации Таможня</h2>
                 <!-- Контентная часть ключей -->
                 <?php foreach ($tamojnya as $ztamojnya => $k_tamojnya): ?>
-
-                    <?php if(in_array($ztamojnya,Yii::$app->params['keysBlocks'])): ?>
-                        <!-- feed recomendations -->
-                        <div class="col-lg-12 item-loot">
-                            <?= $this->render('/other/adsense-feed.php'); ?>
-                        </div>
-                    <?php endif; ?>
-
                     <div class="col-lg-12 item-key">
                         <p class="item-name"><a href="/keys/<?=$k_tamojnya['url']?>"><?=$k_tamojnya['name']?></a></p>
                         <a href="/keys/<?=$k_tamojnya['url']?>"><img class="w-100 f-left fixible custom-key-margin" src="<?=$k_tamojnya['preview']?>"></a>
@@ -102,14 +94,6 @@ $this->registerMetaTag([
                 <h2 class="keys-titles">Ключи на локации Завод</h2>
                 <!-- Контентная часть ключей -->
                 <?php foreach ($zavod as $kzavod => $k_zavod): ?>
-
-                    <?php if(in_array($kzavod,Yii::$app->params['keysBlocks'])): ?>
-                        <!-- feed recomendations -->
-                        <div class="col-lg-12 item-loot">
-                            <?= $this->render('/other/adsense-feed.php'); ?>
-                        </div>
-                    <?php endif; ?>
-
                     <div class="col-lg-12 item-key">
                         <p class="item-name"><a href="/keys/<?=$k_zavod['url']?>"><?=$k_zavod['name']?></a></p>
                         <a href="/keys/<?=$k_zavod['url']?>"><img class="w-100 f-left fixible custom-key-margin" src="<?=$k_zavod['preview']?>"></a>
@@ -124,14 +108,6 @@ $this->registerMetaTag([
                 <h2 class="keys-titles">Ключи на локации Лес</h2>
                 <!-- Контентная часть ключей -->
                 <?php foreach ($forest as $zforest => $k_forest): ?>
-
-                    <?php if(in_array($zforest,Yii::$app->params['keysBlocks'])): ?>
-                        <!-- feed recomendations -->
-                        <div class="col-lg-12 item-loot">
-                            <?= $this->render('/other/adsense-feed.php'); ?>
-                        </div>
-                    <?php endif; ?>
-
                     <div class="col-lg-12 item-key">
                         <p class="item-name"><a href="/keys/<?=$k_forest['url']?>"><?=$k_forest['name']?></a></p>
                         <a href="/keys/<?=$k_forest['url']?>"><img class="w-100 f-left fixible custom-key-margin" src="<?=$k_forest['preview']?>"></a>
@@ -146,14 +122,6 @@ $this->registerMetaTag([
                 <h2 class="keys-titles">Ключи на локации Берег</h2>
                 <!-- Контентная часть ключей -->
                 <?php foreach ($bereg as $zbereg => $k_bereg): ?>
-
-                    <?php if(in_array($zbereg,Yii::$app->params['keysBlocks'])): ?>
-                        <!-- feed recomendations -->
-                        <div class="col-lg-12 item-loot">
-                            <?= $this->render('/other/adsense-feed.php'); ?>
-                        </div>
-                    <?php endif; ?>
-
                     <div class="col-lg-12 item-key">
                         <p class="item-name"><a href="/keys/<?=$k_bereg['url']?>"><?=$k_bereg['name']?></a></p>
                         <a href="/keys/<?=$k_bereg['url']?>"><img class="w-100 f-left fixible custom-key-margin" src="<?=$k_bereg['preview']?>"></a>
@@ -169,14 +137,6 @@ $this->registerMetaTag([
                 <h2 class="keys-titles">Ключи на локации Развязка</h2>
                 <!-- Контентная часть ключей -->
                 <?php foreach ($razvyazka as $zrazvyazka => $k_razvyazka): ?>
-
-                    <?php if(in_array($zrazvyazka,Yii::$app->params['keysBlocks'])): ?>
-                        <!-- feed recomendations -->
-                        <div class="col-lg-12 item-loot">
-                            <?= $this->render('/other/adsense-feed.php'); ?>
-                        </div>
-                    <?php endif; ?>
-
                     <div class="col-lg-12 item-key">
                         <p class="item-name"><a href="/keys/<?=$k_razvyazka['url']?>"><?=$k_razvyazka['name']?></a></p>
                         <a href="/keys/<?=$k_razvyazka['url']?>"><img class="w-100 f-left fixible custom-key-margin" src="<?=$k_razvyazka['preview']?>"></a>


### PR DESCRIPTION
В фиде дублировались блоки вызова одного и того же рекламного кода, как известно многократный вызов на одной страницы одного и того же рекламного блока не приводит к его повторному рендеру.

В связи с чем все повторные вызовы рекламных блоков в фиде отключены в рамках этого MR.