### PR TITLE
Исправлен цвет заголовков на главной странице в Dark Theme теме сайта

### DIFF
--- a/web/css/dark-theme.css
+++ b/web/css/dark-theme.css
@@ -29,6 +29,11 @@ p, p.loot-description {
     color: #c4c4c4
 }
 
+/** Цвет стилей заголовков на главной странице сайта */
+.site-index h2 {
+    color: #c4c4c4;
+}
+
 /** Класс заголовков для */
 .heading-class {
     padding: 50px 0 10px 0;


### PR DESCRIPTION
Поправлен баг, который образовался с темными стилями сайта (На главной странице заголовки разделов сливались с фоном сайта).