### PR TITLE
 Страницы API боссов кешируются Redis

### DIFF
--- a/config/params.php
+++ b/config/params.php
@@ -47,7 +47,8 @@ return [
     ],
     'cacheTime' => [
         'one_hour' => 3600,
-        'seven_days' => 604800
+        'seven_days' => 604800,
+        'one_day' => 86400
     ],
     'discordHookNewsUrl' => 'https://discord.com/api/webhooks/452407880566571008/XUNKYU2VjqAyjx3TW5eCw8vOrzYaohxo4Ym6T025R0hFZ2vwcmr2n0Np9vo88mE_8xSO'
 ];


### PR DESCRIPTION
Теперь страницы API лута с боссами кешируются редисом на 7 дней. Если вдруг данные из таблицы дропнулись и затянулись новые из API, кеш страниц тоже сбросится.