### PR TITLE
Реализован сервис, который редиректит на канонические версии страниц

### DIFF
--- a/common/services/CanonicalPagesService.php
+++ b/common/services/CanonicalPagesService.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: PC_Principal
+ * Date: 15.12.2023
+ * Time: 0:00
+ */
+
+namespace app\common\services;
+
+use Yii;
+
+/**
+ * Сервис для редиректов на канонические страницы приложения
+ * Используется в случаях, когда в поисковые системы попадают дубли
+ * Нюанс архитектуры, по многочисленным причинам на проекте не может использоваться strictParsing в UrlManager'e
+ *
+ * Class CanonicalPagesService
+ * @package app\common\services
+ */
+final class CanonicalPagesService
+{
+    /**
+     * Метод сравнивает запрашиваемый route со своей каноничной версией, если они не совпадают - редиректнет 301 запросом на каноникал урл
+     * Этот метод можно использовать в случаях, когда в поисковые системы попали дубли страниц, хотя это редкий случай на этом проекте
+     *
+     * @param string $canonical_url - Канонический адрес страницы
+     * @param string $requested_url - Url что запрашивал пользователь
+     *
+     * @return \yii\console\Response|\yii\web\Response|bool
+     */
+    public static function redirectToCanonical(string $canonical_url, string $requested_url)
+    {
+        /** Переменная для return'a */
+        $result = false;
+
+        /** Выдергиваем из канонического урла хост и все лишнее */
+        $canonical_url = str_replace(Yii::$app->request->hostInfo, "",$canonical_url);
+
+        /** Если url, который запросили не является частью канонического урла */
+        if ($canonical_url !== $requested_url) {
+
+            /** Возвращаем редиректом на канонический Url адрес */
+            return Yii::$app->response->redirect($canonical_url, 301);
+        }
+
+        /** Возвращаем false - если редиректа не было */
+        return $result;
+    }
+}

--- a/controllers/MapsController.php
+++ b/controllers/MapsController.php
@@ -63,7 +63,7 @@ final class MapsController extends AdvancedController
         return [
             [
                 'class' => 'yii\filters\PageCache',
-                'duration' => Yii::$app->params['cacheTime']['one_hour'],
+                'duration' => Yii::$app->params['cacheTime']['seven_days'],
                 'variations' => RedisVariationsConfig::getMapsControllerVariations()
             ],
         ];

--- a/views/maps/bereg-location.php
+++ b/views/maps/bereg-location.php
@@ -6,6 +6,8 @@
  * Time: 18:23
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
 use yii\web\JqueryAsset;
 
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
@@ -18,6 +20,9 @@ $this->registerMetaTag([
     'name' => 'description',
     'content' => 'Интерактивная карта локации Берег из игры Escape from Tarkov с маркерами расположения военных ящиков, спавнов диких и ЧВК, дверей открываемых ключами.',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 <meta name="viewport" content="initial-scale=1.0, user-scalable=no">

--- a/views/maps/forest-location.php
+++ b/views/maps/forest-location.php
@@ -6,6 +6,9 @@
  * Time: 18:23
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
 $this->registerJsFile('js/leaflet/leaflet.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 $this->registerJsFile('js/map_hash.js', ['depends' => [\yii\web\JqueryAsset::class]]);
@@ -15,6 +18,9 @@ $this->registerMetaTag([
     'name' => 'description',
     'content' => 'Интерактивная карта локации Лес из игры Escape from Tarkov с маркерами расположения военных ящиков, спавнов диких и ЧВК, дверей открываемых ключами.',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 <meta name="viewport" content="initial-scale=1.0, user-scalable=no">

--- a/views/maps/laboratory-location.php
+++ b/views/maps/laboratory-location.php
@@ -6,6 +6,9 @@
  * Time: 21:46
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
 $this->registerJsFile('js/leaflet/leaflet.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 $this->registerJsFile('js/map_hash.js', ['depends' => [\yii\web\JqueryAsset::class]]);
@@ -15,6 +18,9 @@ $this->registerMetaTag([
     'name' => 'description',
     'content' => 'Интерактивная карта локации лаборатория Terra Group из игры Escape from Tarkov с маркерами расположения военных ящиков, спавнов диких и ЧВК, дверей открываемых ключами.',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 

--- a/views/maps/lighthouse.php
+++ b/views/maps/lighthouse.php
@@ -6,6 +6,9 @@
  * Time: 18:36
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
 $this->registerJsFile('js/leaflet/leaflet.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 $this->registerJsFile('js/map_hash.js', ['depends' => [\yii\web\JqueryAsset::class]]);
@@ -16,6 +19,8 @@ $this->registerMetaTag([
     'content' => 'Интерактивная карта локации Маяк из игры Escape from Tarkov.',
 ]);
 
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 

--- a/views/maps/maps.php
+++ b/views/maps/maps.php
@@ -6,6 +6,9 @@
  * Time: 15:05
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->title = 'Карты локаций Escape from Tarkov - интерактивные карты с просмотром ключей от помещений';
 
 $this->registerMetaTag([
@@ -17,6 +20,9 @@ $this->registerMetaTag([
     'name' => 'keywords',
     'content' => 'Карта Леса Тарков, Карта таможни Тарков, Escape from tarkov интерактивные карты',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 <!-- Gorizontal information -->
 <div class="container">

--- a/views/maps/razvyazka-location.php
+++ b/views/maps/razvyazka-location.php
@@ -6,6 +6,9 @@
  * Time: 15:00
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
 $this->registerJsFile('js/leaflet/leaflet.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 $this->registerJsFile('js/map_hash.js', ['depends' => [\yii\web\JqueryAsset::class]]);
@@ -15,6 +18,9 @@ $this->registerMetaTag([
     'name' => 'description',
     'content' => 'Интерактивная карта локации Развязка из игры Escape from Tarkov с маркерами расположения военных ящиков, спавнов диких и ЧВК, дверей открываемых ключами.',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 

--- a/views/maps/rezerv.php
+++ b/views/maps/rezerv.php
@@ -6,6 +6,9 @@
  * Time: 18:08
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
 $this->registerJsFile('js/leaflet/leaflet.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 $this->registerJsFile('js/map_hash.js', ['depends' => [\yii\web\JqueryAsset::class]]);
@@ -15,6 +18,9 @@ $this->registerMetaTag([
     'name' => 'description',
     'content' => 'Интерактивная карта локации Резерв из игры Escape from Tarkov',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 

--- a/views/maps/streets-of-tarkov.php
+++ b/views/maps/streets-of-tarkov.php
@@ -8,6 +8,9 @@
  * Страница с интерактивной картой локации Улицы Таркова
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
 $this->registerJsFile('js/leaflet/leaflet.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 $this->registerJsFile('js/map_hash.js', ['depends' => [\yii\web\JqueryAsset::class]]);
@@ -17,6 +20,9 @@ $this->registerMetaTag([
     'name' => 'description',
     'content' => 'Интерактивная карта локации Улицы Таркова из игры Escape from Tarkov с маркерами расположения военных ящиков, спавнов диких и ЧВК, дверей открываемых ключами.',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 <meta name="viewport" content="initial-scale=1.0, user-scalable=no">

--- a/views/maps/tamojnya-location.php
+++ b/views/maps/tamojnya-location.php
@@ -6,6 +6,9 @@
  * Time: 21:43
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
 $this->registerJsFile('js/leaflet/leaflet.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 $this->registerJsFile('js/map_hash.js', ['depends' => [\yii\web\JqueryAsset::class]]);
@@ -15,6 +18,9 @@ $this->registerMetaTag([
     'name' => 'description',
     'content' => 'Интерактивная карта локации Таможня из игры Escape from Tarkov с маркерами расположения военных ящиков, спавнов диких и ЧВК, выходов с локации за Диких.',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 <meta name="viewport" content="initial-scale=1.0, user-scalable=no">

--- a/views/maps/zavod-location.php
+++ b/views/maps/zavod-location.php
@@ -6,6 +6,9 @@
  * Time: 15:05
  */
 
+use app\common\services\CanonicalPagesService;
+use yii\helpers\Url;
+
 $this->registerCssFile("js/leaflet/leaflet.css", ['depends' => ['app\assets\AppAsset']]);
 $this->registerJsFile('js/leaflet/leaflet.js', ['depends' => [\yii\web\JqueryAsset::class]]);
 $this->registerJsFile('js/map_hash.js', ['depends' => [\yii\web\JqueryAsset::class]]);
@@ -15,6 +18,9 @@ $this->registerMetaTag([
     'name' => 'description',
     'content' => 'Интерактивная карта локации Завод из игры Escape from Tarkov с маркерами расположения военных ящиков, спавнов диких и ЧВК, дверей открываемых ключами.',
 ]);
+
+/** Редирект для неканоничных страниц локаций (Убираем дубли из поисковых систем) */
+CanonicalPagesService::redirectToCanonical(Url::canonical(), Yii::$app->request->url);
 ?>
 
 <meta name="viewport" content="initial-scale=1.0, user-scalable=no">


### PR DESCRIPTION
В данном случае он фиксит дубли, что вылезли в Яндекс Вебмастере. Можно подключать при необходимости, на страницах где возникают подобного рода проблемы.