### PR TITLE
Убираем alerts с новых боссов

### DIFF
--- a/common/services/BossesService.php
+++ b/common/services/BossesService.php
@@ -49,7 +49,10 @@ final class BossesService extends AbstractItemsApiService
             'Кабан (снайпер)' => 710,
             'Santa Claus' => 1040,
             'Колонтай' => 1055,
-            'Партизан' => 950
+            'Партизан' => 950,
+            'Shadow of Tagilla' => 1305,
+            'Vengeful Killa' => 960,
+            'Shadow of Tagilla Disciple' => 1220,
         ];
     }
 

--- a/common/services/ImageService.php
+++ b/common/services/ImageService.php
@@ -90,7 +90,10 @@ final class ImageService extends AbstractItemsApiService
             'Кабан' => '/img/bosses/kaban.jpg',
             'Кабан (снайпер)' => '/img/bosses/kaban_sniper.jpg',
             'Santa Claus' => '/img/bosses/gifter.jpg',
-            'Колонтай' => '/img/bosses/collontay.jpg'
+            'Колонтай' => '/img/bosses/collontay.jpg',
+            'Shadow of Tagilla' => '/img/qsch.png', # Заглушка на этих боссов - ивентовые
+            'Vengeful Killa' => '/img/qsch.png',  # Заглушка на этих боссов - ивентовые
+            'Shadow of Tagilla Disciple' => '/img/qsch.png'  # Заглушка на этих боссов - ивентовые
         ];
 
         /** Если не нашли изображение подходящего босса */


### PR DESCRIPTION
Убираем alerts с новых боссов - чтобы не триггерить логирование, боссы ивентовые - изображения им не добавлялись.

Сбросить REDIS на PROD после релиза, чтобы здоровье боссов подтянулось после релиза.